### PR TITLE
Adding MultiTagParser

### DIFF
--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
@@ -14,6 +14,7 @@ public class CarbonMetric
 {
 	private String m_name;
 	private ImmutableSortedMap.Builder<String, String> m_tags;
+	private int ttl;
 
 	public CarbonMetric(String name)
 	{
@@ -26,6 +27,11 @@ public class CarbonMetric
 		m_tags.put(tag, value);
 	}
 
+	public void setTtl(int ttlValue)
+	{
+		ttl = ttlValue;
+	}
+
 	public String getName()
 	{
 		return m_name;
@@ -35,4 +41,11 @@ public class CarbonMetric
 	{
 		return m_tags.build();
 	}
+
+	public int getTtl()
+	{
+		return ttl;
+	}
+
+
 }

--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
@@ -14,7 +14,7 @@ public class CarbonMetric
 {
 	private String m_name;
 	private ImmutableSortedMap.Builder<String, String> m_tags;
-	private int ttl = 0;
+	private int m_ttl = 0;
 
 	public CarbonMetric(String name)
 	{
@@ -27,9 +27,9 @@ public class CarbonMetric
 		m_tags.put(tag, value);
 	}
 
-	public void setTtl(int ttlValue)
+	public void setTtl(int ttl)
 	{
-		ttl = ttlValue;
+		m_ttl = ttl;
 	}
 
 	public String getName()
@@ -44,7 +44,7 @@ public class CarbonMetric
 
 	public int getTtl()
 	{
-		return ttl;
+		return m_ttl;
 	}
 
 

--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonMetric.java
@@ -14,7 +14,7 @@ public class CarbonMetric
 {
 	private String m_name;
 	private ImmutableSortedMap.Builder<String, String> m_tags;
-	private int ttl;
+	private int ttl = 0;
 
 	public CarbonMetric(String name)
 	{

--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonPickleServer.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonPickleServer.java
@@ -124,7 +124,7 @@ public class CarbonPickleServer extends SimpleChannelUpstreamHandler implements 
 
 				try
 				{
-					m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dataPoint);
+					m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dataPoint, carbonMetric.getTtl());
 				}
 				catch (DatastoreException e)
 				{

--- a/src/main/java/org/kairosdb/plugin/carbon/CarbonTextServer.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/CarbonTextServer.java
@@ -126,7 +126,7 @@ public class CarbonTextServer extends SimpleChannelUpstreamHandler implements Ch
 				else
 					dp = m_longDataPointFactory.createDataPoint(timestamp, Long.parseLong(msgArr[1]));
 
-				m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dp);
+				m_datastore.putDataPoint(carbonMetric.getName(), carbonMetric.getTags(), dp, carbonMetric.getTtl());
 			}
 			catch (Exception e)
 			{

--- a/src/main/java/org/kairosdb/plugin/carbon/MultiTagParser.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/MultiTagParser.java
@@ -1,0 +1,127 @@
+package org.kairosdb.plugin.carbon;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Created by vkrish2 on 8/12/16.
+ */
+public class MultiTagParser implements TagParser {
+    public static final String MULTI_PATTERN_PROP = "kairosdb.carbon.multitagparser.patterns";
+    public static final String MULTI_REPLACEMENT_PROP = "kairosdb.carbon.multitagparser.replacements";
+    public static final String MULTI_TAGS = "kairosdb.carbon.multitagparser.tags";
+
+    public static final String METRIC_PATTERN_PROP = "kairosdb.carbon.multitagparser.metric_pattern";
+    public static final String METRIC_REPLACEMENT_PROP = "kairosdb.carbon.multitagparser.metric_replacement";
+
+    public static final String TAGS_CASE = "kairosdb.carbon.multitagparser.tagscase";
+
+    public static final String METRIC_TTL = "kairosdb.carbon.ttl";
+    public static final String METRIC_INVALID_TTL = "kairosdb.carbon.invalidTtl";
+
+
+    private List<Pattern> m_pattern_list = new ArrayList<Pattern>();
+    private List<String> m_replacement_list = new ArrayList<String>();
+    private List<String> m_tags_list = new ArrayList<String>();
+
+    private Pattern m_metricPattern;
+    private String m_metricReplacement;
+
+    private int m_tags_case = 0;
+    private int invalidTtl = 0;
+    private int ttl = 0;
+
+
+
+    @Inject
+    public MultiTagParser(
+            @Named(MULTI_PATTERN_PROP)String multiPatterns,
+            @Named(MULTI_REPLACEMENT_PROP)String multiReplacements,
+            @Named(MULTI_TAGS)String multiTags,
+            @Named(TAGS_CASE)String tags_case,
+            @Named(METRIC_PATTERN_PROP)String metricPattern,
+            @Named(METRIC_REPLACEMENT_PROP)String metricReplacement,
+            @Named(METRIC_INVALID_TTL)int invalidTtlValue,
+            @Named(METRIC_TTL)int ttlValue)
+    {
+
+
+        String[] m_hostPatterns = multiPatterns.split(";");
+
+        for(String m_hostPatternStr : m_hostPatterns) {
+            m_pattern_list.add(Pattern.compile(m_hostPatternStr.trim()));
+        }
+
+        m_replacement_list = Arrays.asList(multiReplacements.split(";"));
+        m_tags_list = Arrays.asList(multiTags.split(";"));
+
+        m_metricPattern = Pattern.compile(metricPattern);
+        m_metricReplacement = metricReplacement;
+
+        invalidTtl = invalidTtlValue;
+        ttl = ttlValue;
+
+
+        if (tags_case.equalsIgnoreCase("upper")){
+            m_tags_case = 1;
+        }
+        else if (tags_case.equalsIgnoreCase("lower")){
+            m_tags_case = 2;
+        }
+    }
+
+    @Override
+    public CarbonMetric parseMetricName(String metricName)
+    {
+
+        switch(m_tags_case){
+            case 1:
+                metricName = metricName.toUpperCase();
+                break;
+            case 2:
+                metricName = metricName.toLowerCase();
+                break;
+            default:
+                break;
+        }
+
+        Matcher metricMatcher = m_metricPattern.matcher(metricName);
+        CarbonMetric ret;
+
+        if(!metricMatcher.matches()){
+            ret = new CarbonMetric("invalidMetrics");
+            ret.addTag("metricName", metricName);
+            ret.setTtl(invalidTtl);
+            return (ret);
+        }
+
+        Matcher hostMatcher;
+        ret = new CarbonMetric(metricMatcher.replaceAll(m_metricReplacement));
+
+        Iterator<Pattern> patternIterator = m_pattern_list.iterator();
+        Iterator<String> replacementIterator = m_replacement_list.iterator();
+        Iterator<String> tagsIterator = m_tags_list.iterator();
+
+        while(patternIterator.hasNext() && replacementIterator.hasNext() && tagsIterator.hasNext()){
+            hostMatcher = patternIterator.next().matcher(metricName);
+            if (!hostMatcher.matches()){
+                ret = new CarbonMetric("invalidMetrics");
+                ret.addTag("metricName", metricName);
+                ret.setTtl(invalidTtl);
+                return (ret);
+            }
+            ret.addTag(tagsIterator.next().trim(), hostMatcher.replaceAll(replacementIterator.next().trim()));
+        }
+
+        ret.setTtl(ttl);
+        return (ret);
+    }
+}

--- a/src/main/java/org/kairosdb/plugin/carbon/MultiTagParser.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/MultiTagParser.java
@@ -46,7 +46,7 @@ public class MultiTagParser implements TagParser {
             @Named(MULTI_PATTERN_PROP)String multiPatterns,
             @Named(MULTI_REPLACEMENT_PROP)String multiReplacements,
             @Named(MULTI_TAGS)String multiTags,
-            @Named(TAGS_CASE)String tags_case,
+            @Named(TAGS_CASE)String tagsCase,
             @Named(METRIC_PATTERN_PROP)String metricPattern,
             @Named(METRIC_REPLACEMENT_PROP)String metricReplacement,
             @Named(METRIC_INVALID_TTL)int invalidTtlValue,
@@ -70,10 +70,10 @@ public class MultiTagParser implements TagParser {
         ttl = ttlValue;
 
 
-        if (tags_case.equalsIgnoreCase("upper")){
+        if (tagsCase.equalsIgnoreCase("upper")){
             m_tags_case = 1;
         }
-        else if (tags_case.equalsIgnoreCase("lower")){
+        else if (tagsCase.equalsIgnoreCase("lower")){
             m_tags_case = 2;
         }
     }

--- a/src/main/java/org/kairosdb/plugin/carbon/MultiTagParser.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/MultiTagParser.java
@@ -15,17 +15,17 @@ import java.util.regex.Pattern;
  * Created by vkrish2 on 8/12/16.
  */
 public class MultiTagParser implements TagParser {
-    public static final String MULTI_PATTERN_PROP = "kairosdb.carbon.multitagparser.patterns";
-    public static final String MULTI_REPLACEMENT_PROP = "kairosdb.carbon.multitagparser.replacements";
-    public static final String MULTI_TAGS = "kairosdb.carbon.multitagparser.tags";
+    private static final String MULTI_PATTERN_PROP = "kairosdb.carbon.multitagparser.patterns";
+    private static final String MULTI_REPLACEMENT_PROP = "kairosdb.carbon.multitagparser.replacements";
+    private static final String MULTI_TAGS = "kairosdb.carbon.multitagparser.tags";
 
-    public static final String METRIC_PATTERN_PROP = "kairosdb.carbon.multitagparser.metric_pattern";
-    public static final String METRIC_REPLACEMENT_PROP = "kairosdb.carbon.multitagparser.metric_replacement";
+    private static final String METRIC_PATTERN_PROP = "kairosdb.carbon.multitagparser.metric_pattern";
+    private static final String METRIC_REPLACEMENT_PROP = "kairosdb.carbon.multitagparser.metric_replacement";
 
-    public static final String TAGS_CASE = "kairosdb.carbon.multitagparser.tagscase";
+    private static final String TAGS_CASE = "kairosdb.carbon.multitagparser.tagscase";
 
-    public static final String METRIC_TTL = "kairosdb.carbon.ttl";
-    public static final String METRIC_INVALID_TTL = "kairosdb.carbon.invalidTtl";
+    private static final String METRIC_TTL = "kairosdb.carbon.ttl";
+    private static final String METRIC_INVALID_TTL = "kairosdb.carbon.invalidTtl";
 
 
     private List<Pattern> m_pattern_list = new ArrayList<Pattern>();

--- a/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 public class Unpickler extends net.razorvine.pickle.Unpickler
 {
 	private boolean m_firstTuple = true;
-	static int i=0;
+	private int i=0;
 	private boolean is_tuple = false;
 
 	@Override
@@ -46,6 +46,7 @@ public class Unpickler extends net.razorvine.pickle.Unpickler
 		else if ((key == Opcodes.TUPLE))
 		{
 
+			// Skip the first tuple key
 			i++;
 			if(i%2 == 0){
 				i =0 ;
@@ -61,9 +62,11 @@ public class Unpickler extends net.razorvine.pickle.Unpickler
 
 			PickleMetric metric;
 			if (value.toString().contains(".")){
+				// Store the value as Double
 				metric = new PickleMetric(path, time, Double.parseDouble(value.toString()));
 			}
 			else{
+				// Store the value as Long
 				metric = new PickleMetric(path, time, Long.parseLong(value.toString()));
 			}
 
@@ -72,6 +75,7 @@ public class Unpickler extends net.razorvine.pickle.Unpickler
 			is_tuple = true;
 		}
 		else if(key == Opcodes.APPEND && is_tuple){
+			// Append code for tuples
 			is_tuple = false;
 			Object value = stack.pop();
 			stack.pop();

--- a/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
@@ -47,37 +47,27 @@ public class Unpickler extends net.razorvine.pickle.Unpickler
 		{
 
 			i++;
-			System.out.println("i = " + i);
 			if(i%2 == 0){
 				i =0 ;
 				return ;
 			}
 
-			if (m_firstTuple)
-			{
-
-				m_firstTuple = true;
-				//Pop three items from stack
-				Object value = stack.pop();
-				long time = ((Number)stack.pop()).longValue();
-				stack.pop();
-				String path = /*(String)*/stack.pop().toString();
+			//Pop three items from stack
+			Object value = stack.pop();
+			long time = ((Number)stack.pop()).longValue();
+			stack.pop();
+			String path = stack.pop().toString();
 
 
-				PickleMetric metric;
-				if (/*value instanceof Double*/ value.toString().contains(".")){
-					metric = new PickleMetric(path, time, Double.parseDouble(value.toString()));
-				}
-				else{
-					metric = new PickleMetric(path, time, Long.parseLong(value.toString()));
-				}
-
-				stack.add(metric);
-
+			PickleMetric metric;
+			if (value.toString().contains(".")){
+				metric = new PickleMetric(path, time, Double.parseDouble(value.toString()));
 			}
 			else{
-				m_firstTuple = false;
+				metric = new PickleMetric(path, time, Long.parseLong(value.toString()));
 			}
+
+			stack.add(metric);
 
 			is_tuple = true;
 		}
@@ -88,7 +78,6 @@ public class Unpickler extends net.razorvine.pickle.Unpickler
 
 			@SuppressWarnings("unchecked")
 			ArrayList<Object> list = (ArrayList<Object>) stack.peek();
-
 			list.add(value);
 
 		}

--- a/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 public class Unpickler extends net.razorvine.pickle.Unpickler
 {
 	private boolean m_firstTuple = true;
-	private int i=0;
+	private int tupleOpcodeCounter=0;
 	private boolean is_tuple = false;
 
 	@Override
@@ -47,9 +47,9 @@ public class Unpickler extends net.razorvine.pickle.Unpickler
 		{
 
 			// Skip the first tuple key
-			i++;
-			if(i%2 == 0){
-				i =0 ;
+			tupleOpcodeCounter++;
+			if(tupleOpcodeCounter%2 == 0){
+				tupleOpcodeCounter =0 ;
 				return ;
 			}
 

--- a/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
+++ b/src/main/java/org/kairosdb/plugin/carbon/pickle/Unpickler.java
@@ -3,6 +3,8 @@ package org.kairosdb.plugin.carbon.pickle;
 import net.razorvine.pickle.Opcodes;
 
 import java.io.IOException;
+import java.util.ArrayList;
+
 
 /**
  Created with IntelliJ IDEA.
@@ -14,6 +16,8 @@ import java.io.IOException;
 public class Unpickler extends net.razorvine.pickle.Unpickler
 {
 	private boolean m_firstTuple = true;
+	static int i=0;
+	private boolean is_tuple = false;
 
 	@Override
 	protected void dispatch(short key) throws IOException
@@ -38,6 +42,55 @@ public class Unpickler extends net.razorvine.pickle.Unpickler
 			}
 			else
 				m_firstTuple = false;
+		}
+		else if ((key == Opcodes.TUPLE))
+		{
+
+			i++;
+			System.out.println("i = " + i);
+			if(i%2 == 0){
+				i =0 ;
+				return ;
+			}
+
+			if (m_firstTuple)
+			{
+
+				m_firstTuple = true;
+				//Pop three items from stack
+				Object value = stack.pop();
+				long time = ((Number)stack.pop()).longValue();
+				stack.pop();
+				String path = /*(String)*/stack.pop().toString();
+
+
+				PickleMetric metric;
+				if (/*value instanceof Double*/ value.toString().contains(".")){
+					metric = new PickleMetric(path, time, Double.parseDouble(value.toString()));
+				}
+				else{
+					metric = new PickleMetric(path, time, Long.parseLong(value.toString()));
+				}
+
+				stack.add(metric);
+
+			}
+			else{
+				m_firstTuple = false;
+			}
+
+			is_tuple = true;
+		}
+		else if(key == Opcodes.APPEND && is_tuple){
+			is_tuple = false;
+			Object value = stack.pop();
+			stack.pop();
+
+			@SuppressWarnings("unchecked")
+			ArrayList<Object> list = (ArrayList<Object>) stack.peek();
+
+			list.add(value);
+
 		}
 		else
 			super.dispatch(key);

--- a/src/main/resources/kairos-carbon.multiTagParser.properties
+++ b/src/main/resources/kairos-carbon.multiTagParser.properties
@@ -1,22 +1,40 @@
 #===============================================================================
 # Settings for the carbon server protocol handler
 kairosdb.service.carbon=org.kairosdb.plugin.carbon.CarbonServerModule
-kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.CustomTagParser
+kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.MultiTagParser
+
+# Listner Properties
 kairosdb.carbon.text.address=0.0.0.0
 kairosdb.carbon.text.port=2003
 kairosdb.carbon.pickle.address=0.0.0.0
 kairosdb.carbon.pickle.port=2004
 
 #Determins the size of the buffer to allocate for incoming pickles
-kairosdb.carbon.pickle.max_size=2048
+#Increase the value if you run with errors while sending larger data packets
+kairosdb.carbon.pickle.max_size=20480
 
+# Change the case of incoming metrics, tags. Leave blank to not make any changes
+# Allowed values : lower/upper
 kairosdb.carbon.multitagparser.tagscase=lower
+
+# Regex for the Tag's patterns, name of the Tags
 kairosdb.carbon.multitagparser.patterns=()([^.]*[.][^.]*[.][^.]*[.][^.]*)[.].*; ([^.]*[.]){4}([^.]*)[.].*
-        
 kairosdb.carbon.multitagparser.replacements=$2; $2
 kairosdb.carbon.multitagparser.tags=GroupId;ArtifactId
+
+# Regex for the metric name's patterns
 kairosdb.carbon.multitagparser.metric_pattern=(.*[.])(.*)
 kairosdb.carbon.multitagparser.metric_replacement=$2
-        
+
+# TTL value for the metrics; Set 0 for no TTL
 kairosdb.carbon.ttl=8640000
+# TTL value for the metrics not matching with the regex; Set 0 for no TTL
 kairosdb.carbon.invalidTtl=864000
+
+
+# TemplatesTagParser properties
+kairosdb.carbon.templatestagparser.templates=\
+	^stats.counters.statsd .type.metric*;\
+	^stats.gauges.statsd .type.metric*;\
+	^stats.statsd .metric*
+

--- a/src/main/resources/kairos-carbon.multiTagParser.properties
+++ b/src/main/resources/kairos-carbon.multiTagParser.properties
@@ -1,0 +1,22 @@
+#===============================================================================
+# Settings for the carbon server protocol handler
+kairosdb.service.carbon=org.kairosdb.plugin.carbon.CarbonServerModule
+kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.CustomTagParser
+kairosdb.carbon.text.address=0.0.0.0
+kairosdb.carbon.text.port=2003
+kairosdb.carbon.pickle.address=0.0.0.0
+kairosdb.carbon.pickle.port=2004
+
+#Determins the size of the buffer to allocate for incoming pickles
+kairosdb.carbon.pickle.max_size=2048
+
+kairosdb.carbon.multitagparser.tagscase=lower
+kairosdb.carbon.multitagparser.patterns=()([^.]*[.][^.]*[.][^.]*[.][^.]*)[.].*; ([^.]*[.]){4}([^.]*)[.].*
+        
+kairosdb.carbon.multitagparser.replacements=$2; $2
+kairosdb.carbon.multitagparser.tags=GroupId;ArtifactId
+kairosdb.carbon.multitagparser.metric_pattern=(.*[.])(.*)
+kairosdb.carbon.multitagparser.metric_replacement=$2
+        
+kairosdb.carbon.ttl=8640000
+kairosdb.carbon.invalidTtl=864000

--- a/src/main/resources/kairos-carbon.properties
+++ b/src/main/resources/kairos-carbon.properties
@@ -2,6 +2,7 @@
 # Settings for the carbon server protocol handler
 kairosdb.service.carbon=org.kairosdb.plugin.carbon.CarbonServerModule
 kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.HostTagParser
+#kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.MultiTagParser
 kairosdb.carbon.text.address=0.0.0.0
 kairosdb.carbon.text.port=2003
 kairosdb.carbon.pickle.address=0.0.0.0

--- a/src/main/resources/kairos-carbon.properties
+++ b/src/main/resources/kairos-carbon.properties
@@ -2,7 +2,6 @@
 # Settings for the carbon server protocol handler
 kairosdb.service.carbon=org.kairosdb.plugin.carbon.CarbonServerModule
 kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.HostTagParser
-#kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.MultiTagParser
 kairosdb.carbon.text.address=0.0.0.0
 kairosdb.carbon.text.port=2003
 kairosdb.carbon.pickle.address=0.0.0.0

--- a/src/test/java/org/kairosdb/plugin/carbon/CarbonPickleServerTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/CarbonPickleServerTest.java
@@ -82,7 +82,7 @@ public class CarbonPickleServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234),0);
 	}
 
 	@Test
@@ -98,6 +98,6 @@ public class CarbonPickleServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new DoubleDataPoint(now * 1000, 12.34));
+						new DoubleDataPoint(now * 1000, 12.34),0);
 	}
 }

--- a/src/test/java/org/kairosdb/plugin/carbon/CarbonPickleServerTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/CarbonPickleServerTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.*;
 public class CarbonPickleServerTest
 {
 	private final static int CARBON_PORT = 2004;
+	private final int ZERO_TTL = 0;
 
 	private KairosDatastore m_datastore;
 	private CarbonPickleServer m_server;
@@ -82,7 +83,7 @@ public class CarbonPickleServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new LongDataPoint(now * 1000, 1234),0);
+						new LongDataPoint(now * 1000, 1234),ZERO_TTL);
 	}
 
 	@Test
@@ -98,6 +99,6 @@ public class CarbonPickleServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new DoubleDataPoint(now * 1000, 12.34),0);
+						new DoubleDataPoint(now * 1000, 12.34),ZERO_TTL);
 	}
 }

--- a/src/test/java/org/kairosdb/plugin/carbon/CarbonTextServerTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/CarbonTextServerTest.java
@@ -84,7 +84,7 @@ public class CarbonTextServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new LongDataPoint(now * 1000, 1234));
+						new LongDataPoint(now * 1000, 1234), 0);
 	}
 
 	@Test
@@ -100,6 +100,6 @@ public class CarbonTextServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new DoubleDataPoint(now * 1000, 12.34));
+						new DoubleDataPoint(now * 1000, 12.34),0);
 	}
 }

--- a/src/test/java/org/kairosdb/plugin/carbon/CarbonTextServerTest.java
+++ b/src/test/java/org/kairosdb/plugin/carbon/CarbonTextServerTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.verify;
 public class CarbonTextServerTest
 {
 	private final static int CARBON_PORT = 2003;
+	private final int ZERO_TTL = 0;
 
 	private KairosDatastore m_datastore;
 	private CarbonTextServer m_server;
@@ -84,7 +85,7 @@ public class CarbonTextServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new LongDataPoint(now * 1000, 1234), 0);
+						new LongDataPoint(now * 1000, 1234), ZERO_TTL);
 	}
 
 	@Test
@@ -100,6 +101,6 @@ public class CarbonTextServerTest
 
 		verify(m_datastore, timeout(5000).times(1))
 				.putDataPoint("test.metric_name", tags,
-						new DoubleDataPoint(now * 1000, 12.34),0);
+						new DoubleDataPoint(now * 1000, 12.34),ZERO_TTL);
 	}
 }


### PR DESCRIPTION
1. Added MultiTagParser which  …
	a. Allows to define multiple tags
	b. Allows changing the case of metrics, tags to Upper/Lower
	c. Allows adding a TTL
	d. Metrics not matching the reggae, will be stored under metric name "invalidMetrics" with tag name "metricName" as the metric's name and can define a separate TTL for that
2. Fixed the unpickler issue to process the carbon pickle port data.